### PR TITLE
fix deploy-hugo action

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
add permissions.contents: write ([ref](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#readme:~:text=If%20the%20action%20fails%20to%20push%20the%20commit%20or%20tag%20with%20the%20following%20error%3A))